### PR TITLE
Fix get onvif password digest

### DIFF
--- a/samples/OnvifProbe/OnvifDemo.dproj
+++ b/samples/OnvifProbe/OnvifDemo.dproj
@@ -63,6 +63,7 @@
         <DCC_ImageBase>00400000</DCC_ImageBase>
         <DCC_N>false</DCC_N>
         <DCC_F>false</DCC_F>
+        <DCC_UnitSearchPath>..\..\source;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Win32)'!=''">
         <UWP_DelphiLogo44>$(BDS)\bin\Artwork\Windows\UWP\delphi_UwpDefault_44.png</UWP_DelphiLogo44>

--- a/samples/OnvifTestFmx/OnvifTestFmx.dproj
+++ b/samples/OnvifTestFmx/OnvifTestFmx.dproj
@@ -117,6 +117,7 @@
         <Icon_MainIcon>$(BDS)\bin\delphi_PROJECTICON.ico</Icon_MainIcon>
         <Icns_MainIcns>$(BDS)\bin\delphi_PROJECTICNS.icns</Icns_MainIcns>
         <SanitizedProjectName>OnvifTestFmx</SanitizedProjectName>
+        <DCC_UnitSearchPath>..\..\Source;$(DCC_UnitSearchPath)</DCC_UnitSearchPath>
     </PropertyGroup>
     <PropertyGroup Condition="'$(Base_Android)'!=''">
         <DCC_UsePackage>DBXSqliteDriver;bindcompdbx;IndyIPCommon;DBXInterBaseDriver;IndyIPServer;IndySystem;AndroidVoiceComponents;tethering;fmxFireDAC;DialogsPkg;bindcompfmx;FMXTee;DbxCommonDriver;FmxTeeUI;fmx;xmlrtl;rtl;DbxClientDriver;CustomIPTransport;dbexpress;IndyCore;bindcomp;dsnap;IndyIPClient;dbxcds;bindengine;dsnapxml;dbrtl;IndyProtocols;$(DCC_UsePackage)</DCC_UsePackage>


### PR DESCRIPTION
In the port to FMX the AnsiString was removed. So GetONVIFPasswordDigest doesn´t work any longer in Delphi 10.2. I fix it but i cant´t test it in FMX.

Additional i add the search path to the sample projects, so you don't have to define global variables.