### PR TITLE
For DecimalSeparator in german os

### DIFF
--- a/source/ONVIF.pas
+++ b/source/ONVIF.pas
@@ -580,7 +580,12 @@ var
   i, j: Integer;
   Profile: TProfile;
   A: TAnalyticsModule;
+  hFormatSettings: TFormatSettings;
 begin
+  hFormatSettings := FormatSettings;
+  hFormatSettings.DecimalSeparator := '.'; // me 260318 '.' for DecimalSeparator in german os
+  hFormatSettings.ThousandSeparator := ',';
+
   XML := TXmlVerySimple.Create;
   SS := TStringStream.Create(XMLProfiles);
   Result := False;
@@ -649,7 +654,7 @@ begin
             end;
             M := N.Find('Quality');
             if Assigned(M) then
-              Profile.VideoEncoderConfiguration.Quality := M.Text.ToDouble;
+              Profile.VideoEncoderConfiguration.Quality := Double.Parse(M.Text, hFormatSettings); // me 260318 old: M.Text.ToDouble
             M := N.Find('RateControl');
             if Assigned(M) then
             begin


### PR DESCRIPTION
In German the DecimalSeparator is ",", therefore you have to set the decimal separator manually.