### PR TITLE
User lowercase media for "/onvif/media" same as "/onvif/ptz"

### DIFF
--- a/source/ONVIF.pas
+++ b/source/ONVIF.pas
@@ -383,7 +383,7 @@ end;
 
 const
   onvifDeviceService = 'device_service';
-  onvifMedia = 'Media';
+  onvifMedia = 'media'; // me 260318 "/onvif/media" old: 'Media'
 
 function ONVIFProbe: TProbeMatchArray;
 Var


### PR DESCRIPTION
On some devices, the page is not found (404) if the first letter is capitalized.