### PR TITLE
TPoint name collision

### DIFF
--- a/source/ONVIF.pas
+++ b/source/ONVIF.pas
@@ -152,12 +152,12 @@ Type
     Value: String;
   end;
 
-  TPoint = record
+  TRealPoint = record
     x: Real;
     y: Real;
   end;
 
-  TElementItemXY = TPoint;
+  TElementItemXY = TRealPoint;
 
   TElementItemLayout = record
     Columns: Integer;
@@ -166,7 +166,7 @@ Type
     Scale: TElementItemXY;
   end;
 
-  TPolygon = TPoint;
+  TPolygon = TRealPoint;
 
   TElementItemField = TArray<TPolygon>;
 


### PR DESCRIPTION
I renamed the Type because of a name collision in Winapi.Windows 